### PR TITLE
Switch main theme

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,6 @@
 #baseURL: "https://pm-dungeon.github.io/PM-Lecture/"
 baseURL: "https://www.fh-bielefeld.de/elearning/data/FH-Bielefeld/lm_data/lm_1165993/"
+canonifyURLs: true
 
 languageCode: "de-DE"
 metaDataFormat: "yaml"
@@ -23,6 +24,10 @@ params:
   disableSearch: true
   disableLandingPageButton: true
   disableMermaid: true
+  themeVariant:
+  - "green"
+  - "relearn-light"
+  - "relearn-dark"
 
 menu:
   shortcuts:

--- a/config.yaml
+++ b/config.yaml
@@ -6,7 +6,7 @@ languageCode: "de-DE"
 metaDataFormat: "yaml"
 theme:
   - "hugo-lecture"
-  - "hugo-theme-learn"
+  - "hugo-theme-relearn"
 
 themesDir: ".hugo"
 contentDir: "temp/content"

--- a/markdown/misc/credits/index.md
+++ b/markdown/misc/credits/index.md
@@ -31,9 +31,8 @@ Für die Vorverarbeitung des Materials werden die beiden Projekte eingesetzt:
 Die Webseiten für das Unterrichtsmaterial werden mit folgenden Projekten erzeugt:
 
 *   [Hugo](https://github.com/gohugoio/hugo)
-*   [Hugo Learn Theme](https://github.com/matcornic/hugo-theme-learn)
-    (abgeleitet von [Grav](https://github.com/getgrav/grav))
-*   [Hugo-Lecture-Layouts](https://github.com/cagix/Hugo-Lecture-Layouts)
+*   [Hugo Relearn Theme](https://github.com/McShelby/hugo-theme-relearn)
+*   [Hugo-Lecture](https://github.com/cagix/Hugo-Lecture)
 
 In den generierten Webseiten werden u.a. diese Projekte genutzt:
 
@@ -44,7 +43,6 @@ In den generierten Webseiten werden u.a. diese Projekte genutzt:
 ## Weitere genutzte Tools
 
 *   [GNU Make](https://www.gnu.org/software/make/)
-*   [Hugo-Lecture-Archetypes](https://github.com/cagix/Hugo-Lecture-Archetypes)
 *   [Pandoc Dockerfiles](https://github.com/pandoc/dockerfiles)
 *   [Docker](https://www.docker.com/)
 *   [GitHub](https://github.com/)
@@ -53,4 +51,4 @@ In den generierten Webseiten werden u.a. diese Projekte genutzt:
 ## Beitragende
 
 Dieses Projekt wurde und wird erstellt und gepflegt vom Autor [Carsten Gips](https://github.com/cagix)
-sowie weiteren [Beitragenden](https://github.com/PM-Dungeon/Lecture/graphs/contributors).
+sowie weiteren [Beitragenden](https://github.com/PM-Dungeon/PM-Lecture/graphs/contributors).

--- a/static/license.html
+++ b/static/license.html
@@ -4,6 +4,6 @@
     <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/"><img alt="Creative Commons License" style="border-width:0;margin:0;display:inline;" src="https://i.creativecommons.org/l/by-sa/4.0/88x31.png" /></a> Unless otherwise noted, <a href="https://github.com/PM-Dungeon/PM-Lecture">this work</a> by <a xmlns:cc="http://creativecommons.org/ns#" href="https://github.com/cagix" property="cc:attributionName" rel="cc:attributionURL">Carsten Gips</a> and <a href="https://github.com/PM-Dungeon/PM-Lecture/graphs/contributors">contributors</a> is licensed under <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a>.
 <br />
     Icons by <a href="https://fontawesome.com/">Font Awesome</a>.
-    Built with <a href="https://github.com/jgm/pandoc">Pandoc</a> using <a href="https://github.com/cagix/pandoc-lecture">Pandoc-Lecture</a> and <a href="https://github.com/gohugoio/hugo">Hugo</a> using the <a href="https://github.com/matcornic/hugo-theme-learn">Hugo Learn Theme</a> (deriving from <a href="https://github.com/getgrav/grav">Grav</a>).
+    Built with <a href="https://github.com/jgm/pandoc">Pandoc</a> using <a href="https://github.com/cagix/pandoc-lecture">Pandoc-Lecture</a> and <a href="https://github.com/gohugoio/hugo">Hugo</a> using the <a href="https://github.com/McShelby/hugo-theme-relearn">Hugo Relearn Theme</a>.
 </p>
 </div>


### PR DESCRIPTION
Das bisher verwendete [Hugo Learn Theme](https://github.com/matcornic/hugo-theme-learn) wird offenbar nicht mehr gepflegt. Mit [Hugo Relearn Theme](https://github.com/McShelby/hugo-theme-relearn) steht ein Fork zur Verfügung, der nach erster Prüfung direkt kompatibel ist und der aktiv gepflegt wird. Zusätzlich bietet das Theme verschiedene Modes an (light, dark, ...).

Siehe auch #127.
