### PR TITLE
Hugo-config: start toc at level two (again)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -52,7 +52,7 @@ markup:
     renderer:
       unsafe: true
   tableOfContents:
-    startLevel: 1
+    startLevel: 2
 
 privacy:
   disqus:


### PR DESCRIPTION
usually we use headings level 2 and larger. only in compiler construction level 1 is still used in lecture-bc for the outline.