### PR TITLE
Workflows: publish website as .zip and pdf's as branch

### DIFF
--- a/.github/actions/alpine-pandoc-hugo/install-packages.sh
+++ b/.github/actions/alpine-pandoc-hugo/install-packages.sh
@@ -10,7 +10,7 @@ tlmgr install beamertheme-metropolis pgfopts tcolorbox environ || exit 1
 tlmgr install standalone filemod currfile || exit 1
 
 ## Install make and graphviz (dot)
-apk --no-cache add make bash graphviz ghostscript font-noto || exit 1
+apk --no-cache add make bash zip graphviz ghostscript font-noto || exit 1
 
 ## Install current Hugo (linux/64bit/tgz)
 ## https://github.com/gohugoio/hugo/releases/latest/

--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -18,7 +18,6 @@ jobs:
       - uses: ./.github/actions/alpine-pandoc-hugo
         with:
           make-target: 'make web'
-      - run: cd docs/ && zip -r pm.zip *
       - uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -21,6 +21,6 @@ jobs:
       - uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_branch: gh-pages
+          publish_branch: _hugo
           publish_dir: docs/
           force_orphan: true

--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -17,7 +17,7 @@ jobs:
           submodules: true
       - uses: ./.github/actions/alpine-pandoc-hugo
         with:
-          make-target: 'make web'
+          make-target: 'make web_zip'
       - uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -18,6 +18,7 @@ jobs:
       - uses: ./.github/actions/alpine-pandoc-hugo
         with:
           make-target: 'make web'
+      - run: cd docs/ && zip -r pm.zip *
       - uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/slides.yaml
+++ b/.github/workflows/slides.yaml
@@ -22,10 +22,12 @@ jobs:
       - uses: ./.github/actions/alpine-pandoc-hugo
         with:
           make-target: 'make ${{ github.head_ref }}'
-      - uses: actions/upload-artifact@v2
+      - uses: peaceiris/actions-gh-pages@v3
         with:
-          path: pdf/
-          retention-days: 1
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: slides
+          publish_dir: pdf/
+          force_orphan: true
 
   # create all slides: "make slides"
   all-slidedesks:
@@ -38,7 +40,9 @@ jobs:
       - uses: ./.github/actions/alpine-pandoc-hugo
         with:
           make-target: 'make slides'
-      - uses: actions/upload-artifact@v2
+      - uses: peaceiris/actions-gh-pages@v3
         with:
-          path: pdf/
-          retention-days: 1
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: slides
+          publish_dir: pdf/
+          force_orphan: true

--- a/.github/workflows/slides.yaml
+++ b/.github/workflows/slides.yaml
@@ -25,7 +25,7 @@ jobs:
       - uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_branch: slides
+          publish_branch: _slides
           publish_dir: pdf/
           force_orphan: true
 
@@ -43,6 +43,6 @@ jobs:
       - uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_branch: slides
+          publish_branch: _slides
           publish_dir: pdf/
           force_orphan: true

--- a/Makefile
+++ b/Makefile
@@ -203,7 +203,7 @@ web: $(WEB_MARKDOWN_TARGETS) $(WEB_IMAGE_TARGETS) $(WEB_STATIC_TARGETS) $(READIN
 ## Create website and archive
 .PHONY: web_zip
 web_zip: web ## Create website and archive
-	cd $(WEB_OUTPUT_DIR) && zip -r site.zip *
+	cd $(WEB_OUTPUT_DIR) && rm -rf site.zip && zip -r site.zip *
 
 ## Build Docker image "alpine-pandoc-hugo"
 .PHONY: docker

--- a/Makefile
+++ b/Makefile
@@ -200,6 +200,11 @@ $(SLIDES_SHORT_TARGETS): $$(patsubst %,$(SLIDES_OUTPUT_DIR)/%.pdf,$$@)
 web: $(WEB_MARKDOWN_TARGETS) $(WEB_IMAGE_TARGETS) $(WEB_STATIC_TARGETS) $(READINGS) $(HUGO_LOCAL) ## Create website
 	$(HUGO) $(HUGO_ARGS)
 
+## Create website and archive
+.PHONY: web_zip
+web_zip: web ## Create website and archive
+	cd $(WEB_OUTPUT_DIR) && zip -r site.zip *
+
 ## Build Docker image "alpine-pandoc-hugo"
 .PHONY: docker
 docker: ## Build Docker image "alpine-pandoc-hugo"


### PR DESCRIPTION
- website: publish as branch `_hugo`
- website: publish .zip of website (inside `docs/`) on `_hugo` as well
- slides: publish `pdf/` as branch `_slides` instead of uploading artefacts

fixes #133


