### PR TITLE
Makefile: fix handling of shared image folders for single markdown files (slides)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -321,13 +321,13 @@ $(SLIDES_MARKDOWN_TARGETS): $(SLIDES_INTERMEDIATE_DIR)/%: $(SRC_DIR)/%
 ## subfolder.
 ## NOTE: The prerequisites for the images must be added after the 'index.md'
 ## so that '$<' contains the right input file for pandoc.
-## Page-Bundles: path/name/index.md, path/name/images/, name.pdf
+## Page-Bundles: path/name/index.md, path/name/images/, path_name.pdf
 $(SLIDES_BUNDLE_PDF_TARGETS): $$(patsubst $(SLIDES_OUTPUT_DIR)/%.pdf,$(SLIDES_INTERMEDIATE_DIR)/%/index.md, $$(subst _,/,$$@))
 	$(create-folder)
 	$(PANDOC) $(PANDOC_DIRS) -d slides $< -o $@
 $(SLIDES_BUNDLE_PDF_TARGETS): $$(filter $$(patsubst $(SLIDES_OUTPUT_DIR)/%.pdf,$(SLIDES_INTERMEDIATE_DIR)/%, $$(subst _,/,$$@))%, $(SLIDES_IMAGE_TARGETS))
-## Single Markdown Files: path/name.md, path/name.images/, name.pdf
+## Single Markdown Files: path/name.md, path/<images>/, path_name.pdf
 $(SLIDES_SINGLE_PDF_TARGETS): $$(patsubst $(SLIDES_OUTPUT_DIR)/%.pdf,$(SLIDES_INTERMEDIATE_DIR)/%.md, $$(subst _,/,$$@))
 	$(create-folder)
 	$(PANDOC) $(PANDOC_DIRS) -d slides $< -o $@
-$(SLIDES_SINGLE_PDF_TARGETS): $$(filter $$(patsubst $(SLIDES_OUTPUT_DIR)/%.pdf,$(SLIDES_INTERMEDIATE_DIR)/%.images, $$(subst _,/,$$@))%, $(SLIDES_IMAGE_TARGETS))
+$(SLIDES_SINGLE_PDF_TARGETS): $$(filter $$(dir $$(patsubst $(SLIDES_OUTPUT_DIR)/%.pdf,$(SLIDES_INTERMEDIATE_DIR)/%, $$(subst _,/,$$@)))%, $(SLIDES_IMAGE_TARGETS))


### PR DESCRIPTION
Für Single-Markdown-Pages war bisher ein spezieller Ordner `<path>/<page>.images/` im `img.html`-Shortcode fest kodiert. Nachdem mit #282 diese an sich unnötige Beschränkung aufgehoben wurde und nun gemeinsame Abbildungsordner für mehrere, auf einer Ebene liegende Lehreinheiten möglich sind, muss das auch im Makefile angepasst werden. 

Für die Abbildungen wird im `img.html`-Shortcode der `<path>` sowie der im Markdown spezifizierte relative Pfad zur Abbildung zusammengefügt. Beispiel: Für eine Single-Markdown-Page `./markdown/topic/subtopic/foo.md` wird als Pfad `topic/subtopic/` genutzt. Wenn in `foo.md` eine Abbildung `![](img/wuppie.png)` referenziert wird, resultiert das im `img.html`-Shortcode zu `topic/subtopic/img/wuppie.png`. Dies muss im Makefile für das Slide-Target (Variante Single-Markdown-Page) nachgezogen werden.

Für das `slides`-Target des Makefiles (und analog die Targets für die einzelnen Slides) wurden entweder alle Abbildungen im Page-Bundle oder im Unterordner `<path>/<page>.images/` bearbeitet. Letzteres wird jetzt auf **alle Abbildungen im Ordner `<path>/`** erweitert. 

Potentieller Nachteil: Damit werden Abbildungen beim Übersetzen von Single-Markdown-Pages unnötig behandelt, die in parallelen Page-Bundles liegen. (Da aber vermutlich entweder nur Page-Bundles oder nur Single-Markdown-Pages eingesetzt werden, spielt das vielleicht keine so große Rolle.)


Für das `web`-Target wurden ohnehin _immer alle_ Abbildungen behandelt. 
