### PR TITLE
Fix #410: Ergänze Erinnerung zu Javadoc und Logging auf Blatt02

### DIFF
--- a/markdown/assignments/pool_concept/sheet02.md
+++ b/markdown/assignments/pool_concept/sheet02.md
@@ -8,6 +8,12 @@ hidden: true
 ---
 
 
+**Erinnerung**: Die Themen `["Logging"]({{< ref "/coding/logging" >}})`{=markdown} und
+`["Javadoc"]({{< ref "/coding/javadoc" >}})`{=markdown} wurden bereits in der VL
+besprochen und sind ab diesem Blatt im Praktikum einzusetzen (vgl.
+`["Note und Credits > Hinweise zum Praktikum > Punkte und formale Abzüge"]({{< ref "/org/grading" >}})`{=markdown}).
+
+
 ## Logging (6 Punkte)
 
 {{% include "assignments/pool_concept/tasks/logging.md" %}}


### PR DESCRIPTION
Für Blatt02 wurde bereits Javadoc und Logging besprochen, d.h. das ist jetzt immer einzusetzen. Entsprechende(n) Hinweis/Erinnerung auf das Blatt?

Fixes #410 
