### PR TITLE
Schedule: ergänze Testing Intro

### DIFF
--- a/data/schedule.yaml
+++ b/data/schedule.yaml
@@ -47,6 +47,7 @@
   lecture:
     - topic: "/building/gradle"
     - topic: "/building/ci"
+    - topic: "/testing/testing-intro"
     - topic: "/testing/junit-basics"
     - topic: "/testing/testcases"
     - topic: "/coding/tdd"


### PR DESCRIPTION
JUnit Basics wurde in zwei Einheiten gesplittet: Testing Intro und JUnit Basics. 

Trage die neue Einheit im Schedule nach.
