### PR TITLE
Fix Web: make link in B04 visible and hide empty Coding Rules lecture

### DIFF
--- a/markdown/assignments/pool_concept/tasks/gradle.md
+++ b/markdown/assignments/pool_concept/tasks/gradle.md
@@ -1,4 +1,4 @@
-Betrachten Sie das Buildskript `gradle.build` aus [`PM-Dungeon/core`](https://github.com/PM-Dungeon/core/blob/master/code/build.gradle).
+Betrachten Sie das Buildskript `gradle.build` aus [PM-Dungeon/core](https://github.com/PM-Dungeon/core/blob/master/code/build.gradle).
 
 Erklären Sie, in welche Abschnitte das Buildskript unterteilt ist und welche Aufgaben diese
 Abschnitte jeweils erfüllen. Gehen Sie dabei im _Detail_ auf das Plugin `java` und die dort

--- a/markdown/coding/codingrules.md
+++ b/markdown/coding/codingrules.md
@@ -30,6 +30,7 @@ youtube:
 fhmedia:
   - link: ""
     name: "VL Coding Conventions"
+sketch: true
 ---
 
 


### PR DESCRIPTION
- B04: Der Link zum Repo (Gradle-Skript) wurde durch die Darstellung als Inline-Code optisch verdeckt. Jetzt ist der Link normaler Text und sollte dadurch wieder sichtbar sein.
- VL Coding-Rules: Setze die Vorlesung für die Zwischenzeit wieder auf "sketch", bis die Inhalte vorbereitet sind.