### PR TITLE
[Org] Note&Credits: Klarstellung Themen und Notenspiegel E1/E2

### DIFF
--- a/markdown/org/grading.md
+++ b/markdown/org/grading.md
@@ -107,6 +107,10 @@ bekannt gegeben, für den Termin in der Vorlesungszeit siehe `[Fahrplan]({{< ref
 
 **50% Praxis, 50% Theorie**
 
+Die beiden Teilleistungen (praktische Teilnote, theoretische Teilnote) werden vom Prüfungsamt
+einzeln erfasst (je eine einzelne Anmeldung im LSF erforderlich!) und für die Gesamtnote in PM
+gleich gewichtet zusammengerechnet.
+
 [[Hinweis Abgabeslots, Präsenz/Online]{.bsp}]{.slides}
 
 

--- a/markdown/org/grading.md
+++ b/markdown/org/grading.md
@@ -108,7 +108,7 @@ bekannt gegeben, für den Termin in der Vorlesungszeit siehe `[Fahrplan]({{< ref
 **50% Praxis, 50% Theorie**
 
 Die beiden Teilleistungen (praktische Teilnote, theoretische Teilnote) werden vom Prüfungsamt
-einzeln erfasst (je eine einzelne Anmeldung im LSF erforderlich!) und werden vom Prüfungamt
+einzeln erfasst (je eine einzelne Anmeldung im LSF erforderlich!) und werden vom Prüfungsamt
 für die Gesamtnote in PM gleich gewichtet zusammengerechnet.
 
 [[Hinweis Abgabeslots, Präsenz/Online]{.bsp}]{.slides}

--- a/markdown/org/grading.md
+++ b/markdown/org/grading.md
@@ -61,7 +61,7 @@ aus dem **Konzept-Pool** für je 10 Punkte.
 #### Praktische Teilnote
 :::
 
-*   225P Gesamt, 50P Puffer => “Krankheitsregelung”, 175P == 100%
+*   225P gesamt, 50P Puffer => “Krankheitsregelung”, 175P == 100%
 *   4.0: ab 60% v. 175P (105P), alle 4% nächste Teilnote, 1.0: ab 96% v. 175P (168P)
 
 ::: notes
@@ -81,10 +81,25 @@ formalen Aspekte Ihrer Abgaben beziehen.
 
 ### 2. Theoretische Teilleistung
 
-*   Erster Prüfungszeitraum: 2x digitale Prüfung: 1x im Semester ("E-Assessment") plus 1x in erster Prüfungsphase
+*   Erster Prüfungszeitraum: 2x digitale Prüfung: 1x im Semester ("E-Assessment" E1) plus 1x in erster Prüfungsphase (E2)
 *   Zweiter Prüfungszeitraum: _Eine_ digitale Klausur
 
+#### Hinweise zum ersten Prüfungszeitraum
+
+*   Es gibt in E1 und in E2 je maximal 30 Punkte: 60P gesamt
+*   4.0: ab 50% v. 60P (30P), alle 5% nächste Teilnote, 1.0: ab 95% v. 60P (57P)
+
+In E1 sind alle Themen bis einschließlich Woche 8 (KW20) relevant, in E2 wird der
+Fokus auf den Themen ab einschließlich Woche 8 (KW20) liegen.
+
+#### Hinweise zum zweiten Prüfungszeitraum
+
+Der Notenspiegel für die theoretische Prüfung im zweiten Prüfungszeitraum steht noch
+nicht fest. Es sind hier alle in der Veranstaltung besprochenen Themen relevant.
+
 ::: notes
+#### Anmerkungen
+
 Die Prüfung für die theoretische Teilleistung wird als digitale Klausur über eine
 spezielle ILIAS-Instanz ("E-Assessment-Server") durchgeführt.
 

--- a/markdown/org/grading.md
+++ b/markdown/org/grading.md
@@ -108,8 +108,8 @@ bekannt gegeben, für den Termin in der Vorlesungszeit siehe `[Fahrplan]({{< ref
 **50% Praxis, 50% Theorie**
 
 Die beiden Teilleistungen (praktische Teilnote, theoretische Teilnote) werden vom Prüfungsamt
-einzeln erfasst (je eine einzelne Anmeldung im LSF erforderlich!) und für die Gesamtnote in PM
-gleich gewichtet zusammengerechnet.
+einzeln erfasst (je eine einzelne Anmeldung im LSF erforderlich!) und werden vom Prüfungamt
+für die Gesamtnote in PM gleich gewichtet zusammengerechnet.
 
 [[Hinweis Abgabeslots, Präsenz/Online]{.bsp}]{.slides}
 


### PR DESCRIPTION

- [x] Punkte und Notenspiegel Termin 1 : 
    - [x] 30P E1, 30P E2 => Summe 60P. 
    - [x] 50% = 4.0 = 30P, 95% = 1.0 = 57P, alle 5% = 3P die nächste Teilnote
- [x] Hinweis bei Gesamtnote: Das rechnet das Prüfungsamt so aus (aus den beiden Teilleistungen)!
- [x] Themen für E1/E2 sowie für zweiten Zeitraum klarstellen (E2: alles ab letzte Woche plus EIN altes Thema)


Fixes #492
