### PR TITLE
[VL] Add quizzes to RegExp and Method References

### DIFF
--- a/markdown/java-jvm/regexp.md
+++ b/markdown/java-jvm/regexp.md
@@ -36,7 +36,7 @@ outcomes:
   - k3: "Nutzung von Quantifizierern"
   - k3: "Zusammenbauen von komplexen Ausdrücken (u.a. mit Gruppen)"
 quizzes:
-  - link: ""
+  - link: "https://www.fh-bielefeld.de/elearning/goto.php?target=tst_1088505&client_id=FH-Bielefeld"
     name: "Quiz RegExp (ILIAS)"
 assignments:
   - topic: sheet08

--- a/markdown/modern-java/methodreferences.md
+++ b/markdown/modern-java/methodreferences.md
@@ -29,7 +29,7 @@ outcomes:
   - k2: "Funktionales Interfaces (Definition)"
   - k3: "Einsatz von Methoden-Referenzen"
 quizzes:
-  - link: ""
+  - link: "https://www.fh-bielefeld.de/elearning/goto.php?target=tst_1088504&client_id=FH-Bielefeld"
     name: "Quiz Methoden-Referenzen (ILIAS)"
 assignments:
   - topic: sheet08


### PR DESCRIPTION
Die Quizzes für RegExp und Method References sind leider nicht rechtzeitig fertig geworden. Damit die Studis aber nicht länger auf das Material warten müssen, merge ich #487 und #488 vorerst ohne die Quizzes - diese werden über dieses Issue nachgereicht.

- [x] https://github.com/PM-Dungeon/Quizzes/issues/43
- [x] https://github.com/PM-Dungeon/Quizzes/issues/41

Fixes #496


